### PR TITLE
Update for Hedwig master

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add `hedwig_hipchat` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:exml, github: "esl/exml"},
+  [{:exml, github: "paulgray/exml", override: true},
    {:hedwig_hipchat, "~> 0.9.0"}]
 end
 ```

--- a/lib/hedwig_hipchat.ex
+++ b/lib/hedwig_hipchat.ex
@@ -248,7 +248,6 @@ defmodule Hedwig.Adapters.HipChat do
     {room, user} = extract_room_and_user(msg, mapping)
 
     %Hedwig.Message{
-      adapter: {__MODULE__, self},
       ref: make_ref(),
       room: room,
       text: body,

--- a/mix.exs
+++ b/mix.exs
@@ -23,8 +23,8 @@ defmodule HedwigHipChat.Mixfile do
   end
 
   defp deps do
-    [{:exml, github: "esl/exml"},
-     {:hedwig, "~> 1.0.0-rc3"},
+    [{:exml, github: "paulgray/exml", override: true},
+     {:hedwig, github: "hedwig-im/hedwig"},
      {:romeo, "~> 0.4"},
      {:earmark, "~> 0.1", only: :dev},
      {:ex_doc, "~> 0.11", only: :dev}]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{"connection": {:hex, :connection, "1.0.2"},
   "earmark": {:hex, :earmark, "0.2.1"},
   "ex_doc": {:hex, :ex_doc, "0.11.4"},
-  "exml": {:git, "https://github.com/esl/exml.git", "d7b745fa89389b53706a07f33775f1f814c66cb4", []},
+  "exml": {:git, "https://github.com/paulgray/exml.git", "d04d0dfc956bd2bf5d9629a7524c6840eb02df28", []},
   "gproc": {:hex, :gproc, "0.5.0"},
-  "hedwig": {:hex, :hedwig, "1.0.0-rc3"},
+  "hedwig": {:git, "https://github.com/hedwig-im/hedwig.git", "18273f14fb8a6d5869551f0c7a3d2eebb2b3662a", []},
   "romeo": {:hex, :romeo, "0.4.0"}}


### PR DESCRIPTION
This PR is to update this adapter to be inline with the changes discussed in hedwig-im/hedwig#38.

Currently using [esl/exml](/esl/exml) is causing breakage on Romeo. See scrogson/romeo#5.

I'm in the process of updating Romeo to use [fast_xml](/processone/fast_xml). This will be better for the user experience since `fast_xml` is on hex.pm it can just be pulled in along with Romeo.
