### PR TITLE
Remove references to old responder

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ config :alfred, Alfred.Robot,
   aka: "/",
   responders: [
     {Hedwig.Responders.Help, []},
-    {Hedwig.Responders.Panzy, []},
     {Hedwig.Responders.GreatSuccess, []},
     {Hedwig.Responders.ShipIt, []}
   ]
@@ -157,7 +156,6 @@ config :alfred, Alfred.Robot,
   ],
   responders: [
     {Hedwig.Responders.Help, []},
-    {Hedwig.Responders.Panzy, []},
     {Hedwig.Responders.GreatSuccess, []},
     {Hedwig.Responders.ShipIt, []}
   ]

--- a/doc/readme.html
+++ b/doc/readme.html
@@ -135,7 +135,6 @@ config :alfred, Alfred.Robot,
   aka: &quot;/&quot;,
   responders: [
     {Hedwig.Responders.Help, []},
-    {Hedwig.Responders.Panzy, []},
     {Hedwig.Responders.GreatSuccess, []},
     {Hedwig.Responders.ShipIt, []}
   ]</code></pre>
@@ -177,7 +176,6 @@ config :alfred, Alfred.Robot,
   ],
   responders: [
     {Hedwig.Responders.Help, []},
-    {Hedwig.Responders.Panzy, []},
     {Hedwig.Responders.GreatSuccess, []},
     {Hedwig.Responders.ShipIt, []}
   ]</code></pre>

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
-%{"connection": {:hex, :connection, "1.0.2"},
-  "earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.4"},
+%{"connection": {:hex, :connection, "1.0.2", "f4a06dd3ecae4141aa66f94ce92ea4c4b8753069472814932f1cadbc3078ab80", [:mix], []},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "exml": {:git, "https://github.com/paulgray/exml.git", "d04d0dfc956bd2bf5d9629a7524c6840eb02df28", []},
-  "gproc": {:hex, :gproc, "0.5.0"},
-  "hedwig": {:git, "https://github.com/hedwig-im/hedwig.git", "18273f14fb8a6d5869551f0c7a3d2eebb2b3662a", []},
-  "romeo": {:hex, :romeo, "0.4.0"}}
+  "gproc": {:hex, :gproc, "0.5.0", "2df2d886f8f8a7b81a4b04aa17972b5965bbc5bf0100ea6d8e8ac6a0e7389afe", [:rebar], []},
+  "hedwig": {:git, "https://github.com/hedwig-im/hedwig.git", "2cf3ad2b881bdb81e7b2754d70ba1904e5c7a83e", []},
+  "romeo": {:hex, :romeo, "0.4.0", "ace7cd6e13fed9557ece9e4dae8d5e0dd6a17144264c4467c3e4ad2e2bd0e94a", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}]}}


### PR DESCRIPTION
Prior to this commit hedwig_hipchat docs referred to a responder that was
removed from hedwig core in hedwig-im/hedwig@701f11f.
