### PR TITLE
Update romeo to version 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Add `hedwig_hipchat` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:exml, github: "paulgray/exml", override: true},
-   {:hedwig_hipchat, "~> 0.9.0"}]
+  [{:hedwig_hipchat, "~> 0.9.5"}]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule HedwigHipChat.Mixfile do
   use Mix.Project
 
-  @version "0.9.4"
+  @version "0.9.5"
   @source_url "https://github.com/jwarlander/hedwig_hipchat"
 
   def project do
@@ -23,9 +23,8 @@ defmodule HedwigHipChat.Mixfile do
   end
 
   defp deps do
-    [{:exml, github: "paulgray/exml", override: true},
-     {:hedwig, github: "hedwig-im/hedwig"},
-     {:romeo, "~> 0.4"},
+    [{:hedwig, "1.0.0-rc.4"},
+     {:romeo, "~> 0.6"},
      {:earmark, "~> 0.1", only: :dev},
      {:ex_doc, "~> 0.11", only: :dev}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,9 @@
-%{"connection": {:hex, :connection, "1.0.2", "f4a06dd3ecae4141aa66f94ce92ea4c4b8753069472814932f1cadbc3078ab80", [:mix], []},
+%{"connection": {:hex, :connection, "1.0.3", "3145f7416be3df248a4935f24e3221dc467c1e3a158d62015b35bd54da365786", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "exml": {:git, "https://github.com/paulgray/exml.git", "d04d0dfc956bd2bf5d9629a7524c6840eb02df28", []},
+  "fast_xml": {:hex, :fast_xml, "1.1.14", "23d4de66e645bca1d8a557444e83062cc42f235d7a7e2d4072d525bac3986f04", [:rebar3], [{:p1_utils, "1.0.4", [hex: :p1_utils, optional: false]}]},
   "gproc": {:hex, :gproc, "0.5.0", "2df2d886f8f8a7b81a4b04aa17972b5965bbc5bf0100ea6d8e8ac6a0e7389afe", [:rebar], []},
-  "hedwig": {:git, "https://github.com/hedwig-im/hedwig.git", "2cf3ad2b881bdb81e7b2754d70ba1904e5c7a83e", []},
-  "romeo": {:hex, :romeo, "0.4.0", "ace7cd6e13fed9557ece9e4dae8d5e0dd6a17144264c4467c3e4ad2e2bd0e94a", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}]}}
+  "hedwig": {:hex, :hedwig, "1.0.0-rc.4", "7c134a19bec8508f8dfd308c69d37426e7bcb48f41cc0cb9366ad7514bb7fd40", [:mix], [{:gproc, "~> 0.5", [hex: :gproc, optional: false]}]},
+  "p1_utils": {:hex, :p1_utils, "1.0.4", "7face65db102b5d1ebe7ad3c7517c5ee8cfbe174c6658e3affbb00eb66e06787", [:rebar3], []},
+  "romeo": {:hex, :romeo, "0.6.0", "a37de89b26e2db040c9650090cc3d1460fd0e93a918634a91aa70897c83f71a9", [:mix], [{:fast_xml, "~> 1.1", [hex: :fast_xml, optional: false]}, {:connection, "~> 1.0", [hex: :connection, optional: false]}]}}


### PR DESCRIPTION
This PR updates romeo to 0.6.0 which replaces `exml` for `fast_xml`. This PR also fixes #3

Please verify that this works as expected. Thanks.
